### PR TITLE
Fix json dumped

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For this work, we just need to create the tasks, so in *stockpile/roles/example/
 
 ### Scenario 1: You want to capture all the interface details. So, you might consider the below.
 
-```ansible
+```yaml
 ---
 
 # Capture the data you are interested in
@@ -58,7 +58,7 @@ Example output of the above Example role:
 
 For this work, we just need to create the tasks, so in *stockpile/roles/example2/tasks/main.yaml*
 
-```ansible
+```yaml
 ---
 
 # Capture the data you are interested in

--- a/stockpile/roles/dump-facts/templates/dump_facts.j2
+++ b/stockpile/roles/dump-facts/templates/dump_facts.j2
@@ -1,7 +1,7 @@
 [
 {% if groups['all'] is defined %}
  {% for host in groups['all'] %}
-  {{hostvars[host]| to_nice_json}},
+  {{hostvars[host]| to_nice_json}}
  {% endfor %}
 {% endif %}
 ]


### PR DESCRIPTION
There was a ',' at the end of the data structure dumped. This creating a
invalid JSON document.

Fixes #23 