### PR TITLE
Collect openshift node configuration info from configmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Please make sure that you follow the below mentioned norms:
 4. Prefix the dictionary with "stockpile_".
 5. Don't try to build the dictionary using the vars directly, lets say if you
 run a shell command to set var1, while building dictionary use var1.stdout
+6. Make sure to add conditions in the roles in order to ensure that the data 
+is collected only if the intended component is installed.
 
 Please look at the example below:
 

--- a/roles/openshift-cluster-topology/files/openshift_config_scraper.py
+++ b/roles/openshift-cluster-topology/files/openshift_config_scraper.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import yaml
+import sys
+import os
+import json
+import argparse
+
+ocp_node_configmap_path = "/tmp/node-config.yaml"
+ocp_webconsole_configmap_path = "/tmp/webconsole-config.yaml"
+ocp_cluster_info_configmap_path = "/tmp/id"
+ocp_config_dir = "/tmp"
+
+def scrape_configmap(cfg_type, namespace, configmap_path):
+    cmd = "oc extract configmap/%s -n %s --confirm --to=%s &>/dev/null" %(cfg_type,namespace,ocp_config_dir)
+    os.system(cmd)
+    with open(configmap_path, "r") as configmap:
+        try:
+            config = yaml.load(configmap)
+        except yaml.YAMLError as e:
+            print ("Error in the configmap file:%s" %(e))
+        try:
+            print (json.dumps(config, indent=4))
+        except ValueError as err:
+            print ("Error while converting to json: %s" %(err))
+
+def main(cfg_type):
+    if cfg_type == "node-config-compute":
+       namespace = "openshift-node"
+       scrape_configmap(cfg_type, namespace, ocp_node_configmap_path)
+    elif cfg_type == "webconsole-config":
+       namespace = "openshift-web-console"
+       scrape_configmap(cfg_type, namespace, ocp_webconsole_configmap_path)
+    elif cfg_type == "node-config-master":
+       namespace = "openshift-node"
+       scrape_configmap(cfg_type, namespace, ocp_node_configmap_path)
+    elif cfg_type == "node-config-infra":
+       namespace = "openshift-node"
+       scrape_configmap(cfg_type, namespace, ocp_node_configmap_path)
+    elif cfg_type == "cluster-info":
+       namespace = "kube-service-catalog"
+       scrape_configmap(cfg_type, namespace, ocp_cluster_info_configmap_path)
+    else:
+       print ("%s is not a valid config type, please check" %(cfg_type))
+       sys.exit(1)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config_type", help="config_type can be one of the follwing: node-config-compute, node-config-master, node-config-infra, webconsole-config, cluster-info")
+    args = parser.parse_args()
+    status = main(args.config_type)
+    sys.exit(status)

--- a/roles/openshift-cluster-topology/tasks/main.yml
+++ b/roles/openshift-cluster-topology/tasks/main.yml
@@ -79,6 +79,22 @@
       shell: oc get pvc --all-namespaces -o json
       register: ocp_pvc
 
+    - name: openshift compute node config
+      script: openshift_config_scraper.py node-config-compute
+      register: ocp_compute_configmap 
+
+    - name: openshift master node config
+      script: openshift_config_scraper.py node-config-master
+      register: ocp_master_configmap
+
+    - name: openshift web-console config
+      script: openshift_config_scraper.py webconsole-config
+      register: ocp_webconsole_configmap
+
+    - name: openshift infra node config
+      script: openshift_config_scraper.py node-config-infra
+      register: ocp_infra_configmap
+
     - name: set the collected info as facts
       set_fact:
         stockpile_openshift_cluster_topology:
@@ -99,5 +115,8 @@
           persistent_volumes: "{{ ocp_pv.stdout }}"
           persistent_volume_claim: "{{ ocp_pvc.stdout }}"
           kubernetes_server_version: "{{ kube_server_version }}"
-           
-  when: ( oc_installed.rc == 0 and kubeconfig.stat.exists == True )
+          node_config_compute: "{{ ocp_compute_configmap.stdout }}"
+          node_config_master: "{{ ocp_master_configmap.stdout }}"
+          node_config_infra: "{{ ocp_infra_configmap.stdout }}"
+          web_console_config: "{{ ocp_webconsole_configmap.stdout }}"
+  when: ( oc_installed.rc == 0 and kubeconfig.stat.exists == True ) 

--- a/roles/openshift-nodes/tasks/main.yml
+++ b/roles/openshift-nodes/tasks/main.yml
@@ -27,12 +27,6 @@
     - name: get the docker storage driver info
       shell: docker info | grep -w "Storage Driver" | cut -d ':' -f2
       register: docker_storage_driver_info
-
-    - name: set docker info as facts
-      set_fact:
-        openshift_docker:
-          - version: "{{ docker_version_installed.stdout }}"
-          - storage_driver: "{{ docker_storage_driver_info.stdout }}"
   when: ( docker_installed.rc == 0 and docker_status.rc == 0 )
 
 - name: check if oc client is installed
@@ -87,6 +81,8 @@
       set_fact:
         stockpile_openshift_node:
           virtualization: "{{ virtualization_info.stdout }}"
+          docker_version: "{{ docker_version_installed.stdout }}"
+          docker_storage_driver: "{{ docker_storage_driver_info.stdout }}"
           tests_version: "{{ ocp_tests_version.stdout }}"
           pod_version: "{{ ocp_pod_version.stdout }}"
           node_version: "{{ ocp_node_version.stdout }}"


### PR DESCRIPTION
This commit adds support to openshift_cluster_topology role to
collect configuration information of master, infra, web-console
e.t.c. These configs contain information including
max-pods-per-node, master apiserver qps and burst rates e.t.c