### PR TITLE
Collect more ocp content and enable the collection by default

### DIFF
--- a/ci/Dockerfile.centos-7
+++ b/ci/Dockerfile.centos-7
@@ -13,7 +13,7 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN yum -y install epel-release
-RUN yum -y install git ansible sudo
+RUN yum -y install git ansible sudo which
 
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 

--- a/roles/openshift-cluster-topology/tasks/main.yml
+++ b/roles/openshift-cluster-topology/tasks/main.yml
@@ -2,15 +2,16 @@
 - name: check if oc client is installed
   shell: which oc
   register: oc_installed
+  ignore_errors: yes
 
 - name: check if kubeconfig exists
   stat:
     path: "{{ ansible_env.HOME }}/.kube/config"
   register: kubeconfig
 
-- name: fail if oc client or kubeconfig doesn't exist
-  fail:
-    msg: Cannot find kubeconfig at "{{ ansible_env.HOME }}/.kube/config", please check.
+- name: print debug msg if oc client or kubeconfig doesn't exist
+  debug:
+    msg: Skipping the ocp collection, cannot find kubeconfig at "{{ ansible_env.HOME }}/.kube/config" or oc client is not installed, please check.
   when: ( oc_installed.rc != 0 or kubeconfig.stat.exists == False )
 
 - block:
@@ -38,9 +39,45 @@
       shell: oc version | grep -w openshift | cut -d ' ' -f2
       register: oc_server_version
 
+    - name: kubernetes server version
+      shell: oc version | grep -w kubernetes | cut -d ' ' -f2 | uniq
+      register: kube_server_version
+
     - name: openshift user
       shell: oc whoami
       register: ocp_user
+
+    - name: infra pods
+      shell: for infra_node in $(oc get nodes -l node-role.kubernetes.io/infra=true | awk 'NR>1 {print $1}' ); do oc get pods --all-namespaces --field-selector spec.nodeName=$infra_node -o wide | awk 'NR>1 {print $2}'; done
+      register: ocp_infra_pods
+
+    - name: get the system pod names in crashloop state
+      shell: oc get pods -n kube-system -o wide | grep -v "Running" | awk 'NR>1 {print $1}'
+      register: ocp_failed_pods
+
+    - name: get the components status
+      shell: oc get cs -o json
+      register: ocp_components_status
+
+    - name: services
+      shell: oc get svc --all-namespaces -o json
+      register: ocp_svc
+
+    - name: services accounts
+      shell: oc get sa --all-namespaces -o json
+      register: ocp_sa
+
+    - name: security contxt constraints
+      shell: oc get scc --all-namespaces -o json
+      register: ocp_scc
+    
+    - name: persistent volumes
+      shell: oc get pv --all-namespaces -o json
+      register: ocp_pv
+
+    - name: persistent volume claims
+      shell: oc get pvc --all-namespaces -o json
+      register: ocp_pvc
 
     - name: set the collected info as facts
       set_fact:
@@ -53,4 +90,14 @@
           client_version: "{{ oc_client_version.stdout }}"
           server_version: "{{ oc_server_version.stdout }}"
           user: "{{ ocp_user.stdout }}"
+          infra_pods: "{{ ocp_infra_pods.stdout.split('\n') }}"
+          failed_system_pods: "{{ ocp_failed_pods.split('\n') }}"
+          components_status: "{{ ocp_components_status.stdout }}"
+          services: "{{ ocp_svc.stdout }}"
+          service_accounts: "{{ ocp_sa.stdout }}"
+          security_context_constraints: "{{ ocp_scc.stdout }}"
+          persistent_volumes: "{{ ocp_pv.stdout }}"
+          persistent_volume_claim: "{{ ocp_pvc.stdout }}"
+          kubernetes_server_version: "{{ kube_server_version }}"
+           
   when: ( oc_installed.rc == 0 and kubeconfig.stat.exists == True )

--- a/roles/openshift-nodes/tasks/main.yml
+++ b/roles/openshift-nodes/tasks/main.yml
@@ -2,17 +2,23 @@
 - name: check if the docker is installed
   shell: which docker
   register: docker_installed
+  ignore_errors: yes
 
-- name: ensure that docker is running
-  service:
-    name: docker
-    state: started
+- block:
+   - name: ensure that docker is running
+     service:
+       name: docker
+       state: started
 
-- name: docker status
-  command: systemctl status docker
-  register: docker_status
-  failed_when: docker_status.rc != 0
-    
+   - name: docker status
+     command: systemctl status docker
+     register: docker_status
+     
+   - debug: 
+       msg: "{{ docker_status.stdout }}"
+     when: docker_status.rc != 0
+  when: docker_installed.rc == 0
+
 - block:
     - name: get the docker version
       shell: docker --version | cut -d "," -f1 | cut -d ' ' -f3
@@ -27,43 +33,68 @@
         openshift_docker:
           - version: "{{ docker_version_installed.stdout }}"
           - storage_driver: "{{ docker_storage_driver_info.stdout }}"
-  when: docker_installed.rc == 0
+  when: ( docker_installed.rc == 0 and docker_status.rc == 0 )
 
-- name: determine virtualization technology
-  shell: dmidecode -s system-product-name
-  register: virtualization_info
+- name: check if oc client is installed
+  shell: which oc
+  register: oc_installed
+  ignore_errors: yes
 
-- name: get atomic openshift tests rpm version
-  shell: rpm -q --qf "%{VERSION}" atomic-openshift-tests
-  register: ocp_tests_version
+- name: check if kubeconfig exists
+  stat:
+    path: "{{ ansible_env.HOME }}/.kube/config"
+  register: kubeconfig
 
-- name: get atomic openshift pod version
-  shell: rpm -q --qf "%{VERSION}" atomic-openshift-pod
-  register: ocp_pod_version
+- name: print debug message if oc client or kubeconfig doesn't exist
+  debug:
+    msg: Skipping the ocp collection, cannot find kubeconfig at "{{ ansible_env.HOME }}/.kube/config" or oc client is not installed, please check.
+  when: ( oc_installed.rc != 0 or kubeconfig.stat.exists == False )
 
-- name: get atomic openshift node version
-  shell: rpm -q --qf "%{VERSION}" atomic-openshift-node
-  register: ocp_node_version
+- block:
+    - name: determine virtualization technology
+      shell: dmidecode -s system-product-name
+      register: virtualization_info
 
-- name: get atomic openshift docker registry version
-  shell: rpm -q --qf "%{VERSION}" atomic-openshift-dockerregistry
-  register: ocp_dockerregistry_version
+    - name: get atomic openshift tests rpm version
+      shell: rpm -q --qf "%{VERSION}" atomic-openshift-tests
+      register: ocp_tests_version
 
-- name: get tuned profiles version
-  shell: rpm -q --qf "%{VERSION}" tuned-profiles-atomic
-  register: tuned_profiles_atomic
+    - name: get atomic openshift pod version
+      shell: rpm -q --qf "%{VERSION}" atomic-openshift-pod
+      register: ocp_pod_version
 
-- name: kernel version
-  shell: uname -r
-  register: kernel_info
+    - name: get atomic openshift node version
+      shell: rpm -q --qf "%{VERSION}" atomic-openshift-node
+      register: ocp_node_version
 
-- name: set collected info as facts
-  set_fact:
-    stockpile_openshift_nodes:
-      virtualization: "{{ virtualization_info.stdout }}"
-      tests_version: "{{ ocp_tests_version.stdout }}"
-      pod_version: "{{ ocp_pod_version.stdout }}"
-      node_version: "{{ ocp_node_version.stdout }}"
-      dockerregistry_version: "{{ ocp_dockerregistry_version.stdout }}"
-      tuned_profiles_version: "{{ tuned_profiles_atomic.stdout }}"
-      kernel_version: "{{ kernel_info.stdout }}"
+    - name: get atomic openshift docker registry version
+      shell: rpm -q --qf "%{VERSION}" atomic-openshift-dockerregistry
+      register: ocp_dockerregistry_version
+
+    - name: get tuned profiles version
+      shell: rpm -q --qf "%{VERSION}" tuned-profiles-atomic
+      register: tuned_profiles_atomic
+
+    - name: kernel version
+      shell: uname -r
+      register: kernel_info
+
+    - name: get node info
+      shell: oc get node $(hostname) -o json
+      register: ocp_node_info 
+    
+    - name: set collected info as facts
+      set_fact:
+        stockpile_openshift_node:
+          virtualization: "{{ virtualization_info.stdout }}"
+          tests_version: "{{ ocp_tests_version.stdout }}"
+          pod_version: "{{ ocp_pod_version.stdout }}"
+          node_version: "{{ ocp_node_version.stdout }}"
+          dockerregistry_version: "{{ ocp_dockerregistry_version.stdout }}"
+          tuned_profiles_version: "{{ tuned_profiles_atomic.stdout }}"
+          kernel_version: "{{ kernel_info.stdout }}"
+          capacity: "{{ ocp_node_info.stdout | from_json | json_query('status.capacity') }}"
+          allocatable: "{{ ocp_node_info.stdout | from_json | json_query('status.allocatable') }}"
+          node_info: "{{ ocp_node_info.stdout | from_json | json_query('status.nodeInfo') }}"
+          daemon_endpoints: "{{ ocp_node_info.stdout | from_json | json_query('status.daemonEndpoints') }}"
+  when: ( oc_installed.rc == 0 or kubeconfig.stat.exists == True )

--- a/stockpile.yml
+++ b/stockpile.yml
@@ -8,6 +8,8 @@
     - dmidecode
     - yum_repos
     - ceph
+    - openshift-cluster-topology
+    - openshift-nodes
     #- example
     #- example2
     #- compute


### PR DESCRIPTION
This commit:
- Adds the openshift roles to the stockpile playbook to enable the
  collection by default.
- Adds support to collect more ocp info including node capacity,
  and allocatable resources, infra pods e.t.c.