### PR TITLE
fixing yum_repos

### DIFF
--- a/roles/yum_repos/tasks/main.yml
+++ b/roles/yum_repos/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if yum is present
-  shell: which yum
+  shell: python -c "import yum"
   register: yum_installed
   ignore_errors: yes
 


### PR DESCRIPTION
yum python module needs to be present before using
yum module in ansible, and thus we need to check if yum module for
python exists before using yum module