### PR TITLE
Add ignore_errors: yes by default to all roles

### DIFF
--- a/stockpile.yml
+++ b/stockpile.yml
@@ -2,6 +2,7 @@
 - hosts: all
   remote_user: "{{ host_remote_user }}"
   become: true
+  ignore_errors: yes
   roles:
     - openstack_common
     #- packages


### PR DESCRIPTION
There are times where roles may fail (such as dmidecode). Setting ignore_errors: yes by default for the roles we can continue on despite errors that may occur. Additionally, many of these roles already have this set in the individual role so it would really just be making it a default.